### PR TITLE
[Feature] onSnapshot 메소드 사용하여 메세지 목록 가져오기 구현 완료

### DIFF
--- a/src/pages/Chatting/components/MessageInput.tsx
+++ b/src/pages/Chatting/components/MessageInput.tsx
@@ -1,14 +1,23 @@
 import { useState } from 'react';
-import { set, ref } from 'firebase/database';
-import { database } from '../../../firebase';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { currentUser } from '../../../recoil/userState';
 import { AiFillPlusCircle } from 'react-icons/ai';
-import { data } from 'autoprefixer';
+import { db } from '../../../firebase';
+import { doc, updateDoc } from 'firebase/firestore';
+import { docsNum } from '../../../recoil/chatRoomState';
 
 export default function MessageInput() {
   const [input, setInput] = useState('');
+  const docsId = useRecoilValue(docsNum);
   const [userEmail] = useRecoilState(currentUser);
+
+  const docRef = doc(db, 'messages', docsId);
+
+  const updatedData = {
+    user: userEmail,
+    chat: input,
+    updatedAt: new Date(),
+  };
 
   const changeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInput(e.target.value);
@@ -17,14 +26,11 @@ export default function MessageInput() {
   const sendHandler = (e: any) => {
     e.preventDefault();
     setInput('');
-
-    // set(ref(database), {
-    //   username: userEmail,
-    //   message: input,
-    // });
-
-    // database.collection('messages');
-    // const chatRef = firestore.collection('messages');
+    try {
+      updateDoc(docRef, updatedData);
+    } catch (e) {
+      console.log(e);
+    }
   };
 
   return (

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,14 +1,14 @@
+import { useEffect, useState } from 'react';
+import { useSetRecoilState } from 'recoil';
 import ChattingRoom from './components/ChattingRoom';
 import { collection, addDoc, getDocs } from 'firebase/firestore';
 import { db } from '../../firebase';
 import Swal from 'sweetalert2';
+import { roomNum } from '../../recoil/chatRoomState';
 import { useNavigate } from 'react-router-dom';
-import { useEffect, useState } from 'react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
-import { docsNum, roomNum } from '../../recoil/chatRoomState';
 
 export default function Home() {
-  const [roomId, setRoomId] = useRecoilState(roomNum);
+  const setRoomId = useSetRecoilState(roomNum);
   const [roomInfo, setRoomInfo] = useState<
     { roomTitle: string; docId: string }[]
   >([]);
@@ -55,7 +55,7 @@ export default function Home() {
       if (result.isConfirmed) {
         const roomValue = result.value;
         submitHandler(roomValue);
-        navigate(`/chatting/${roomId}`);
+        // navigate(`chatting/${roomInfo.docsId}`);
       }
     });
   };

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -4,19 +4,25 @@ import { db } from '../../firebase';
 import Swal from 'sweetalert2';
 import { useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { useRecoilState } from 'recoil';
-import { roomNum } from '../../recoil/chatRoomState';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { docsNum, roomNum } from '../../recoil/chatRoomState';
 
 export default function Home() {
   const [roomId, setRoomId] = useRecoilState(roomNum);
-  const [roomTitles, setRoomTitles] = useState<string[]>([]);
+  const [roomInfo, setRoomInfo] = useState<
+    { roomTitle: string; docId: string }[]
+  >([]);
+
   const navigate = useNavigate();
 
   useEffect(() => {
     const fetchMessages = async () => {
       const querySnapshot = await getDocs(collection(db, 'messages'));
-      const roomTitles = querySnapshot.docs.map(doc => doc.data().roomTitle);
-      setRoomTitles(roomTitles);
+      const newRoomInfo = querySnapshot.docs.map(doc => ({
+        roomTitle: doc.data().roomTitle,
+        docId: doc.id,
+      }));
+      setRoomInfo(newRoomInfo);
     };
 
     fetchMessages();
@@ -56,9 +62,18 @@ export default function Home() {
 
   return (
     <div className="p-3">
-      {roomTitles.map((title: string, idx: number) => {
-        return <ChattingRoom key={idx} title={title} idx={idx} />;
-      })}
+      {roomInfo.map(
+        (room: { roomTitle: string; docId: string }, idx: number) => {
+          return (
+            <ChattingRoom
+              key={idx}
+              docId={room.docId}
+              roomTitle={room.roomTitle}
+              idx={idx}
+            />
+          );
+        }
+      )}
 
       <div className="w-full m-auto">
         <button onClick={newChatRoom} className="btn btn-neutral w-full">

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -5,15 +5,12 @@ import { collection, addDoc, getDocs } from 'firebase/firestore';
 import { db } from '../../firebase';
 import Swal from 'sweetalert2';
 import { roomNum } from '../../recoil/chatRoomState';
-import { useNavigate } from 'react-router-dom';
 
 export default function Home() {
   const setRoomId = useSetRecoilState(roomNum);
   const [roomInfo, setRoomInfo] = useState<
     { roomTitle: string; docId: string }[]
   >([]);
-
-  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchMessages = async () => {
@@ -26,7 +23,7 @@ export default function Home() {
     };
 
     fetchMessages();
-  }, []);
+  }, [roomInfo]);
 
   const submitHandler = (roomValue: string) => {
     try {
@@ -55,7 +52,6 @@ export default function Home() {
       if (result.isConfirmed) {
         const roomValue = result.value;
         submitHandler(roomValue);
-        // navigate(`chatting/${roomInfo.docsId}`);
       }
     });
   };

--- a/src/pages/Home/components/ChattingRoom.tsx
+++ b/src/pages/Home/components/ChattingRoom.tsx
@@ -1,21 +1,28 @@
 import { useNavigate } from 'react-router-dom';
-import { useRecoilState, useSetRecoilState } from 'recoil';
-import { roomNum, roomTitleStr } from '../../../recoil/chatRoomState';
+import { useSetRecoilState } from 'recoil';
+import { docsNum, roomNum, roomTitleStr } from '../../../recoil/chatRoomState';
 
 type ChattingRoomProps = {
-  title: string;
+  roomTitle: string;
+  docId: string;
   idx: number;
 };
 
-export default function ChattingRoom({ title, idx }: ChattingRoomProps) {
+export default function ChattingRoom({
+  roomTitle,
+  docId,
+  idx,
+}: ChattingRoomProps) {
   const navigate = useNavigate();
-  const [roomId, setRoomId] = useRecoilState(roomNum);
+  const setRoomId = useSetRecoilState(roomNum);
+  const setDocsId = useSetRecoilState(docsNum);
   const setRoomTitle = useSetRecoilState(roomTitleStr);
 
   const clickHandler = (e: React.MouseEvent<HTMLButtonElement>) => {
     const id = e.currentTarget.value;
     setRoomId(id);
-    setRoomTitle(title);
+    setRoomTitle(roomTitle);
+    setDocsId(e.currentTarget.name);
     navigate(`/chatting/${id}`);
   };
 
@@ -23,11 +30,16 @@ export default function ChattingRoom({ title, idx }: ChattingRoomProps) {
     <div>
       <div className="card h-[150px] w-full bg-base-100 shadow-xl mb-3">
         <div className="card-body">
-          <h2 className="card-title">{title}</h2>
+          <h2 className="card-title">{roomTitle}</h2>
 
           <div className="card-actions justify-end">
             <div className="w-[410px] ">
-              <button onClick={clickHandler} value={idx} className="btn w-full">
+              <button
+                onClick={clickHandler}
+                value={idx}
+                name={docId}
+                className="btn w-full"
+              >
                 참여하기
               </button>
             </div>

--- a/src/recoil/chatRoomState.tsx
+++ b/src/recoil/chatRoomState.tsx
@@ -14,3 +14,9 @@ export const roomTitleStr = atom({
   default: '',
   effects_UNSTABLE: [persistAtom],
 });
+
+export const docsNum = atom({
+  key: 'docsNum',
+  default: 0,
+  effects_UNSTABLE: [persistAtom],
+});


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 레이아웃 추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
<br />

## :: 구현 목표
1. 메세지 보내면 firestore 문서 업데이트 기능 구현하기
2. onSnapshot 메소드 사용하여 메세지 목록 가져오기
<br />

## :: 구현 사항 설명
- updateDoc 메소드 사용해 선택한 채팅방(=문서) chat 내용 업데이트 할 수 있도록 구현 완료
- onSnapshot 메소드 사용하여 업데이트 된 chat 내용 가져오기 구현 완료
<br />

## :: 코드 기록
- 인자로 들어갈 내용들을 변수로 정리한 다음에 updateDoc 메소드 사용하면 편리하고, 유지보수도 쉽다!
```
  const docRef = doc(db, 'messages', docsId);

  const updatedData = {
    user: userEmail,
    chat: input,
    updatedAt: new Date(),
  };

  updateDoc(docRef, updatedData);

```

## :: 알게된 점
- getDoc 메소드 사용해서 useEffect에 의존성배열로 messageList 입력 후 메세지 추가하면 무한렌더링이 발생 -> onSnapshot 메소드 사용하면 문서가 업데이트 될때마다 messageList가 변경되어 무한렌더링 방지 할 수 있다.
- onSnapshot :  사용자가 제공하는 콜백이 최초로 호출될 때 단일 문서의 현재 콘텐츠로 문서 스냅샷이 즉시 생성됩니다. 그런 다음 콘텐츠가 변경될 때마다 콜백이 호출되어 문서 스냅샷을 업데이트합니다.

